### PR TITLE
Fix camera drift when the viewport height/width isn't divisible by 2

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -62,8 +62,8 @@ void Camera::handleInputs(GLFWwindow* window) {
 		mouseX += double(screen_width % 2) / 2.0;
 		mouseY += double(screen_height % 2) / 2.0;
 		
-		float rotX = sensitivity * (float)(mouseY - (screen_height / 2)) / screen_height;
-		float rotY = sensitivity * (float)(mouseX - (screen_width / 2)) / screen_width;
+		float rotX = sensitivity * (float(mouseY) - (float(screen_height) / 2.0f)) / screen_height;
+		float rotY = sensitivity * (float(mouseX) - (float(screen_width) / 2.0f)) / screen_width;
 
 		vec3 new_orientation = rotate(direction, radians(-rotX), normalize(cross(direction, up)));
 		if (abs(angle(new_orientation, up) - radians(90.0f)) <= radians(85.0f))

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -58,6 +58,10 @@ void Camera::handleInputs(GLFWwindow* window) {
 
 		double mouseX, mouseY;
 		glfwGetCursorPos(window, &mouseX, &mouseY);
+
+		mouseX += double(screen_width % 2) / 2.0;
+		mouseY += double(screen_height % 2) / 2.0;
+		
 		float rotX = sensitivity * (float)(mouseY - (screen_height / 2)) / screen_height;
 		float rotY = sensitivity * (float)(mouseX - (screen_width / 2)) / screen_width;
 


### PR DESCRIPTION
When `screen_width` or `screen_height` isn't divisible by 2 the camera will drift by a small amount every frame, the simplest way to fix this is to modulo `screen_width`/`screen_height` by 2, divide by 2, and then offset the cursor by it.