### PR TITLE
print error if file not found

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -15,6 +15,10 @@ void Mesh::LoadSimpleOBJ(const char* path) {
 	vector<Triangle> mesh;
 
 	FILE* file = fopen(path, "r");
+	if (file == NULL) {
+		perror(path)
+		return 1;
+	}
 	positions.push_back({0, 0, 0});
 	normals.push_back({0, 0, 0});
 	do {
@@ -63,6 +67,10 @@ void Mesh::LoadOBJ(const char* path) {
 	vector<Triangle> mesh;
 
 	FILE* file = fopen(path, "r");
+	if (file == NULL) {
+		perror(path)
+		return 1;
+	}
 	// OBJ indices start at 1
 	positions.push_back({0, 0, 0});
 	normals.push_back({0, 0, 0});
@@ -128,6 +136,10 @@ void Mesh::LoadOBJ(const char* path) {
 
 void Mesh::SaveOBJ(const char* path) {
 	FILE* output = fopen(path, "w");
+	if (file == NULL) {
+		perror(path)
+		return 1;
+	}
 	for (unsigned int i = 0; i < vertices.size(); i++)
 		fprintf(output, "v %f %f %f\n", vertices[i].position.x, vertices[i].position.y, vertices[i].position.z);
 	for (unsigned int i = 0; i < vertices.size(); i++)


### PR DESCRIPTION
Hi,

I was playing around and wanted to try out your work.

This patch prevents a crash and shows that the following mesh related files are not available.

meshes/LTM1300.obj
meshes/LTM1300.png
meshes/LTM1300_specular.png
meshes/LTM1300_glass.obj
meshes/glass.png
